### PR TITLE
:ambulance: (apps/jellyfin): add missing intel opencl package and bump jellyfin version

### DIFF
--- a/charts/jellyfin/images/jellyfin/Dockerfile
+++ b/charts/jellyfin/images/jellyfin/Dockerfile
@@ -14,6 +14,9 @@ FROM docker.io/library/ubuntu:jammy
 # renovate: datasource=github-releases depName=jellyfin/jellyfin versioning=semver extractVersion=^v(?<version>\S+)
 ARG JELLYFIN_VERSION=10.8.13
 
+# Add build arguments for specific architectures
+ARG TARGETPLATFORM
+
 ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
 # hadolint ignore=DL3008
@@ -39,7 +42,9 @@ RUN groupadd jellyfin --gid 64710 \
     && apt-get install --assume-yes --no-install-recommends \
       jellyfin="${JELLYFIN_VERSION}*" \
       mesa-va-drivers \
-      intel-opencl-icd \
+    && if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+      apt-get install --assume-yes --no-install-recommends intel-opencl-icd \
+    ; fi \
     && ln -s /usr/share/jellyfin-ffmpeg/ff* /usr/bin \
     && ln -s /usr/share/jellyfin-ffmpeg/vainfo /usr/bin \
     && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/* \

--- a/charts/jellyfin/images/jellyfin/Dockerfile
+++ b/charts/jellyfin/images/jellyfin/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
 FROM docker.io/library/ubuntu:jammy
 
 # renovate: datasource=github-releases depName=jellyfin/jellyfin versioning=semver extractVersion=^v(?<version>\S+)
-ARG JELLYFIN_VERSION=10.8.12
+ARG JELLYFIN_VERSION=10.8.13
 
 ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
@@ -39,6 +39,7 @@ RUN groupadd jellyfin --gid 64710 \
     && apt-get install --assume-yes --no-install-recommends \
       jellyfin="${JELLYFIN_VERSION}*" \
       mesa-va-drivers \
+      intel-opencl-icd \
     && ln -s /usr/share/jellyfin-ffmpeg/ff* /usr/bin \
     && ln -s /usr/share/jellyfin-ffmpeg/vainfo /usr/bin \
     && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/* \


### PR DESCRIPTION
added intel-opencl-icd package from ubuntu universe for amd64 targets to support HDR tone mapping in transcoding sessions when intel hardware is used for acceleration of the transcoding process.
this change required adding `ARG TARGETPLATFORM` to the dockerfile so we can check that var later on (its contents get provided by the `--platform` build parameter of the github actions) and decide if we install that package or not (it 1. dosnt exist for arm64, and 2. not even makes sense there since intel has no say with arm^^)

i also bumped jellyfin's version to get the container to successfully build

tested and verified using a local build which can be pulled from:

`harbor.crystalnet.org/library/jellyfin:10.8.13`

fixes https://github.com/beluga-cloud/charts/issues/273